### PR TITLE
Added a Simple test SMS service to see the Auth code via web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Queue Management Systems for LPG vendor agencies of Sri Lanka, for the LPG short
 * By default, the system uses [FastSMS (Sri Lanka)](https://fastsms.lk/) service.
 * If the service needs to be changed, `sendSMS()` function in `common/sms.php` needs to be changed.
 * The configuration parameters in `common/config.php` needs to be changed accordingly.
+* The configuration parameters in `common/config.php` sms=>prod has been set to false this will provide UI to view the SMS via /api/v1/send?phone_number=07xxxxxxxx format url 
 
 ### Steps
 <span style="color: red">[INCOMPLETE]</span>

--- a/common/config.php
+++ b/common/config.php
@@ -16,5 +16,6 @@ const CONFIG = [
         'mask' => 'FastSMS',
         'baseUri' => 'https://fastsms.lk',
         'apiKey' => '1234',
+        'prod' => false,
     ],
 ];

--- a/common/sms.php
+++ b/common/sms.php
@@ -7,26 +7,45 @@ use GuzzleHttp\Client;
 
 function sendSMS($to, $text): bool
 {
-    $client = new Client(['base_uri' => CONFIG['sms']['baseUri'], 'timeout' => 2.0]);
-    $response = $client->request('POST', '/api/v1/send', [
-        'headers' => [
-            'Content-Type' => 'application/json',
-            'Accept' => 'application/json',
-            'bearer' => CONFIG['sms']['apiKey'],
-        ],
-        'json' => [
-            'phone_number' => preg_replace('/^0/', '94', $to),
-            'name' => 'Customer',
-            'message' => $text,
-            'mask' => CONFIG['sms']['mask'],
-        ],
-    ]);
+    $data = [
+        'phone_number' => preg_replace('/^0/', '94', $to),
+        'name' => 'Customer',
+        'message' => $text,
+        'mask' => CONFIG['sms']['mask'],
+    ];
+    if(CONFIG['sms']['prod']){
+        $client = new Client(['base_uri' => CONFIG['sms']['baseUri'], 'timeout' => 2.0]);
+        $response = $client->request('POST', '/api/v1/send', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
+                'bearer' => CONFIG['sms']['apiKey'],
+            ],
+            'json' => $data,
+        ]);
 
-    $result = json_decode($response->getBody());
+        $result = json_decode($response->getBody());
 
-    if ($result->error) {
-        throw new \Exception($result->message, $result->code);
+        if ($result->error) {
+            throw new \Exception($result->message, $result->code);
+        }
+    } else {
+        mockTestSMS($data);
+        return true;
     }
 
+
     return true;
+}
+
+function mockTestSMS($get_input): void
+{
+
+    $fp = fopen('api/v1/display'.$get_input['phone_number'].'.txt', 'w+');//opens file in append mode
+    fwrite($fp, "===========================================================\n");
+    fwrite($fp, $get_input['phone_number'] . '('.$get_input['name'].')' );
+    fwrite($fp, "\n=========================**================================\n");
+    fwrite($fp, $get_input['message'].')' );
+    fwrite($fp, "\n=========================**================================");
+    fclose($fp);
 }

--- a/web/api/v1/send.php
+++ b/web/api/v1/send.php
@@ -1,0 +1,22 @@
+<?php
+require_once '../../../common/config.php';
+if(CONFIG['sms']['prod']){
+    header("HTTP/1.0 404 Not Found");
+    exit();
+}
+$fileName =  'display'.preg_replace('/^0/', '94',$_GET['phone_number']).'.txt';
+
+$homepage = file_get_contents(dirname(__FILE__).DIRECTORY_SEPARATOR.$fileName);
+?>
+<html>
+<head>
+    <title><?php echo $fileName ?></title>
+    <meta http-equiv="refresh" content="5" />
+</head>
+<body>
+<textarea cols="100" rows="10">
+    <?php echo $homepage?>
+</textarea>
+</body>
+</html>
+

--- a/web/api/v1/sms_display.sh
+++ b/web/api/v1/sms_display.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+phone=
+
+if [ $# -gt 0 ]
+  then
+    phone=$1
+fi
+PROMPT_COMMAND='echo -ne "\033]0;${phone}\007"'
+tailf "display${phone}.txt"


### PR DESCRIPTION
Added a Simple test SMS service to see the Auth code via web UI

New config value "prod" has been added for testing
also OTP SMS data can be access via /api/v1/send?phone_number=07xxxxxxxx format url